### PR TITLE
OTT-614: Rename the module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/asaskevich/govalidator
+module github.com/PubMatic-OpenWrap/govalidator
 
 go 1.13


### PR DESCRIPTION
Rename the module name so that it can be 
- imported as "github.com/PubMatic-OpenWrap/govalidator"
- downloaded using "go get" command